### PR TITLE
refactor(gih): clean up version handling and arg formatting

### DIFF
--- a/gih/main.go
+++ b/gih/main.go
@@ -12,8 +12,7 @@ import (
 
 // set by build
 var (
-	version   = "0.16.0"
-	goversion = "1.26.2"
+	version = "0.16.0"
 )
 
 const usage = `Run git command to all repositories in the current directory.
@@ -54,15 +53,9 @@ func main() {
 		return
 	}
 
-	if flag.Arg(0) == "version" {
-		_, err := fmt.Fprintf(os.Stdout, "git-here %s\n", version)
-		if err != nil {
-			panic(err)
-		}
-		_, err = fmt.Fprintf(os.Stdout, "go version %s\n", goversion)
-		if err != nil {
-			panic(err)
-		}
+	switch flag.Arg(0) {
+	case "version":
+		printVersion()
 		return
 	}
 
@@ -70,7 +63,7 @@ func main() {
 		*conNum = runtime.NumCPU()
 	}
 
-	fmt.Printf("args: targetDir: %s ignoreDir: %s  concurrency: %d  timeout: %v\n", *targetDir, *ignoreDir, *conNum, *timeout)
+	fmt.Printf("args: targetDir: %s ignoreDir: %s concurrency: %d timeout: %v\n", *targetDir, *ignoreDir, *conNum, *timeout)
 
 	writer := os.Stdout
 	errWriter := os.Stderr
@@ -96,5 +89,16 @@ func main() {
 	}
 	if summary != nil && summary.HasFailures() {
 		os.Exit(2)
+	}
+}
+
+func printVersion() {
+	_, err := fmt.Fprintf(os.Stdout, "git-here %s\n", version)
+	if err != nil {
+		panic(err)
+	}
+	_, err = fmt.Fprintf(os.Stdout, "go version %s\n", runtime.Version())
+	if err != nil {
+		panic(err)
 	}
 }


### PR DESCRIPTION
## Issue

`tasks/improvements-review-2026-04-26.md` 残課題 #13（13 項目中 12 完了の最後の 1 項目）。`gih/main.go` の軽微なクリーンアップ。

## Overview

`gih/main.go` の 3 サブ項目に対応。ユーザー機能影響ゼロの純粋な保守性向上。

### 変更内容

1. **`goversion` を `runtime.Version()` 化**
   - ハードコードされた `goversion = "1.26.2"` 変数を削除
   - `gih version` の go バージョン表示を `runtime.Version()` の戻り値に変更
   - 手動更新で腐るリスクを排除し、実行している Go ランタイムのバージョンを正確に表示

2. **出力フォーマットの 2 スペースを 1 スペースに統一**
   - `args:` 出力行の `concurrency:` / `timeout:` 前の 2 スペースを 1 スペースに統一
   - 旧: `targetDir: %s ignoreDir: %s  concurrency: %d  timeout: %v`
   - 新: `targetDir: %s ignoreDir: %s concurrency: %d timeout: %v`

3. **subcommand を `if` から `switch` + `printVersion()` 関数に整理**
   - `if flag.Arg(0) == "version"` を `switch` 文に変更
   - version 表示処理を `printVersion()` 関数に切り出し
   - 将来 subcommand を追加する際の差分が `case "X": runX()` の 1 行で済む形に

### 検証

- `make build && make test && make lint` すべてグリーン
- E2E:
  - `gih_dev version` → `git-here '0.0.1-test'` + `go version go1.26.2`
  - `gih_dev --target "^x" --ignore "^y" status` → `args: targetDir: ^x ignoreDir: ^y concurrency: N timeout: 20s`（1 スペース統一）
  - 通常 git command（`gih_dev fetch` 等）は switch を通過して syncer に正常委譲
  - 引数なし → `flag.Usage()` 表示で exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)